### PR TITLE
Documentation: fix latest version redirection example

### DIFF
--- a/templates/core/about/redirections.html
+++ b/templates/core/about/redirections.html
@@ -52,7 +52,7 @@
 
                 <tr>
                     <td>
-                        <a href="https://docs.rs/clap/*/clap/struct.App.html">docs.rs/clap/*/clap/struct.App.html</a>
+                        <a href="https://docs.rs/clap/*">docs.rs/clap/*</a>
                     </td>
                     <td>
                         Latest version of this page (if it still exists). "latest" or "newest" work as well as


### PR DESCRIPTION
The current example links to https://docs.rs/clap/*/clap/struct.App.html which does not exist.
It is also not really in line with all the other examples, which do not directly link to any crate items.

![image](https://user-images.githubusercontent.com/64036709/216792019-9ede81ca-c123-4214-a6ea-be4951624884.png)

This PR just changes the link to [https://docs.rs/clap/*](https://docs.rs/clap/*) but https://docs.rs/clap/*/clap/struct.Arg.html would be a struct that currently exists and could be used insted.

